### PR TITLE
Closes #19 automatically release on CocoaPods when we use git tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ osx_image: xcode7.3
 xcode_sdk: iphonesimulator9.3
 
 script: xcodebuild -workspace Commercetools.xcworkspace -scheme "Commercetools" -destination "platform=iOS Simulator,name=iPhone 6" test
+
+deploy:
+  provider: script
+  script: ./scripts/deploy.sh
+  on:
+    tags: true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source ~/.rvm/scripts/rvm
+rvm use default
+pod trunk push


### PR DESCRIPTION
@cneijenhuis @lauraluiz - this enabled us to have automatic release on CocoaPods. After pushing a new tag, travis ci will execute `pod trunk push`. I have already setup the necessary `COCOAPODS_TRUNK_TOKEN` environment variable in the travis config for this project.