### PR TITLE
Closes #36 Updated tests not to use object UUIDs

### DIFF
--- a/CommercetoolsTests/ByIdEndpointTests.swift
+++ b/CommercetoolsTests/ByIdEndpointTests.swift
@@ -11,7 +11,7 @@ class ByIdEndpointTests: XCTestCase {
         static let path = "me/carts"
     }
 
-    private class TestProductProjections: ByIdEndpoint {
+    private class TestProductProjections: ByIdEndpoint, QueryEndpoint {
         static let path = "product-projections"
     }
     
@@ -75,16 +75,16 @@ class ByIdEndpointTests: XCTestCase {
 
         let byIdExpectation = expectationWithDescription("byId expectation")
 
-        let username = "swift.sdk.test.user2@commercetools.com"
-        let password = "password"
-
-        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
-
-        TestProductProjections.byId("a9fd9c74-d00a-4de7-8258-6a9920abc66b", expansion: ["productType"], result: { result in
-            if let response = result.response, productType = response["productType"] as? [String: AnyObject],
+        TestProductProjections.query(limit: 1, result: { result in
+            if let response = result.response, results = response["results"] as? [[String: AnyObject]],
+                    id = results.first?["id"] as? String where result.isSuccess {
+                TestProductProjections.byId(id, expansion: ["productType"], result: { result in
+                    if let response = result.response, productType = response["productType"] as? [String: AnyObject],
                     productTypeObject = productType["obj"] as? [String: AnyObject]
                     where result.isSuccess && productTypeObject.count > 0 {
-                byIdExpectation.fulfill()
+                        byIdExpectation.fulfill()
+                    }
+                })
             }
         })
 

--- a/CommercetoolsTests/QueryEndpointTests.swift
+++ b/CommercetoolsTests/QueryEndpointTests.swift
@@ -31,8 +31,10 @@ class QueryEndpointTests: XCTestCase {
 
         TestProductProjections.query(predicates: [predicate], result: { result in
             if let response = result.response, count = response["count"] as? Int,
-                    results = response["results"] as? [[String: AnyObject]], id = results.first?["id"] as? String
-                    where result.isSuccess && count == 1 && id == "a9fd9c74-d00a-4de7-8258-6a9920abc66b" {
+                    results = response["results"] as? [[String: AnyObject]],
+                    slug = results.first?["slug"] as? [String: String],
+                    enSlug = slug["en"] where result.isSuccess && count == 1
+                    && enSlug == "michael-kors-bag-30T3GTVT7L-lightbrown" {
                 queryExpectation.fulfill()
             }
         })
@@ -78,9 +80,9 @@ class QueryEndpointTests: XCTestCase {
 
         TestProductProjections.query(sort: ["name.en asc", "slug.en asc"], limit: 1, result: { result in
             if let response = result.response, count = response["count"] as? Int,
-            results = response["results"] as? [[String: AnyObject]],
-            name = results.first?["name"] as? [String: String], enName = name["en"]
-            where result.isSuccess && count == 1 && enName == "Alberto Guardiani – Slip on “Cherie”" {
+                    results = response["results"] as? [[String: AnyObject]],
+                    name = results.first?["name"] as? [String: String], enName = name["en"]
+                    where result.isSuccess && count == 1 && enName == "Alberto Guardiani – Slip on “Cherie”" {
                 queryExpectation.fulfill()
             }
         })


### PR DESCRIPTION
@cneijenhuis @lauraluiz In our tests, we've been using UUID references, which needed to be removed, and tests refactored to run without them. We addressed it in this issue.