### PR TITLE
Closes #44 Refactored query endpoint after API update

### DIFF
--- a/Source/Core/QueryEndpoint.swift
+++ b/Source/Core/QueryEndpoint.swift
@@ -43,40 +43,34 @@ public extension QueryEndpoint {
                 return
             }
 
-            let fullPath = pathWithQueryOptions(basePath: path, predicates: predicates, sort: sort, expansion: expansion,
-                                                limit: limit, offset: offset)
+            let fullPath = pathWithExpansion(path, expansion: expansion)
+            let parameters = queryParameters(predicates: predicates, sort: sort, expansion: expansion, limit: limit,
+                                             offset: offset)
 
-            Alamofire.request(.GET, fullPath, parameters: nil, encoding: .URL, headers: self.headers(token))
+            Alamofire.request(.GET, fullPath, parameters: parameters, encoding: .URL, headers: self.headers(token))
             .responseJSON(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), completionHandler: { response in
                 handleResponse(response, result: result)
             })
         }
     }
 
-    private static func pathWithQueryOptions(basePath basePath: String, predicates: [String]? = nil, sort: [String]? = nil,
+    private static func queryParameters(predicates predicates: [String]? = nil, sort: [String]? = nil,
                                         expansion: [String]? = nil, limit: UInt? = nil,
-                                        offset: UInt? = nil) -> String {
-        var fullPath = pathWithExpansion(basePath, expansion: expansion)
-
-        if fullPath.hasSuffix("/") {
-            fullPath = fullPath.substringToIndex(fullPath.endIndex.advancedBy(-1))
-        }
-        if !fullPath.characters.contains("?") {
-            fullPath += "?"
-        }
+                                        offset: UInt? = nil) -> [String: AnyObject] {
+        var parameters = [String: AnyObject]()
 
         if let predicates = predicates where predicates.count > 0 {
-            fullPath += "&where=" + predicates.map({ ParameterEncoding.URL.escape($0) }).joinWithSeparator("&where=")
+            parameters["where"] = predicates
         }
         if let sort = sort where sort.count > 0 {
-            fullPath += "&sort=" + sort.map({ ParameterEncoding.URL.escape($0) }).joinWithSeparator("&sort=")
+            parameters["sort"] = sort
         }
         if let limit = limit {
-            fullPath += "&limit=\(limit)"
+            parameters["limit"] = limit
         }
         if let offset = offset {
-            fullPath += "&offset=\(offset)"
+            parameters["offset"] = offset
         }
-        return fullPath
+        return parameters
     }
 }


### PR DESCRIPTION
@cneijenhuis @lauraluiz - Now we're using encoding provided by Alamofire, after @cneijenhuis updated the API to support array params in the URL with `[]` suffix.