### PR TITLE
Closes #43 Refactor tests which require higher scope

### DIFF
--- a/Commercetools.xcodeproj/xcshareddata/xcschemes/Commercetools.xcscheme
+++ b/Commercetools.xcodeproj/xcshareddata/xcschemes/Commercetools.xcscheme
@@ -37,17 +37,6 @@
                BlueprintName = "CommercetoolsTests"
                ReferencedContainer = "container:Commercetools.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "CustomerTests/testResetPassword()">
-               </Test>
-               <Test
-                  Identifier = "CustomerTests/testVerifyEmail()">
-               </Test>
-               <Test
-                  Identifier = "UpdateByKeyEndpointTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>
@@ -81,6 +70,28 @@
             ReferencedContainer = "container:Commercetools.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PROJECT_KEY"
+            value = "$(CT_SDK_TEST_PROJECT_KEY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SCOPE"
+            value = "$(CT_SDK_TEST_SCOPE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CLIENT_ID"
+            value = "$(CT_SDK_TEST_CLIENT_ID)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "CLIENT_SECRET"
+            value = "$(CT_SDK_TEST_CLIENT_SECRET)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/CommercetoolsTests/Core/UpdateByKeyEndpointTests.swift
+++ b/CommercetoolsTests/Core/UpdateByKeyEndpointTests.swift
@@ -15,19 +15,12 @@ class UpdateByKeyEndpointTests: XCTestCase {
         super.setUp()
 
         cleanPersistedTokens()
-        setupTestConfiguration()
+        setupProjectManagementConfiguration()
     }
 
     override func tearDown() {
         cleanPersistedTokens()
         super.tearDown()
-    }
-
-    override func setupTestConfiguration() {
-        // For update by key tests which include product type, we need a configuration which
-        // contains manage_products scope.
-        let config = [:]
-        Commercetools.config = Config(config: config)
     }
 
     func testUpdateEndpoint() {

--- a/CommercetoolsTests/Endpoints/CustomerTests.swift
+++ b/CommercetoolsTests/Endpoints/CustomerTests.swift
@@ -23,13 +23,6 @@ class CustomerTests: XCTestCase {
         super.tearDown()
     }
 
-    private func setupProjectManagementConfiguration() {
-        // For creating password reset and account activation tokens, we need a configuration which
-        // contains manage_customers scope.
-        let config = [:]
-        Commercetools.config = Config(config: config)
-    }
-
     func testRetrieveCustomerProfile() {
         setupTestConfiguration()
 

--- a/CommercetoolsTests/XCTestCase+Configuration.swift
+++ b/CommercetoolsTests/XCTestCase+Configuration.swift
@@ -14,6 +14,18 @@ extension XCTestCase {
             Commercetools.config = Config(config: config)
         }
     }
+
+    func setupProjectManagementConfiguration() {
+        let envVars = NSProcessInfo.processInfo().environment
+        // For creating password reset and account activation tokens, we need a configuration which
+        // contains manage_customers scope.
+        if let projectKey = envVars["PROJECT_KEY"], scope = envVars["SCOPE"], clientId = envVars["CLIENT_ID"],
+        clientSecret = envVars["CLIENT_SECRET"] {
+
+            let config = ["projectKey": projectKey, "scope": scope, "clientId": clientId, "clientSecret": clientSecret]
+            Commercetools.config = Config(config: config)
+        }
+    }
     
     func cleanPersistedTokens() {
         let tokenStore = AuthManager.sharedInstance.tokenStore
@@ -21,5 +33,5 @@ extension XCTestCase {
         tokenStore.refreshToken = nil
         tokenStore.tokenValidDate = nil
     }
-    
+
 }

--- a/CommercetoolsTests/XCTestCase+Configuration.swift
+++ b/CommercetoolsTests/XCTestCase+Configuration.swift
@@ -24,6 +24,9 @@ extension XCTestCase {
 
             let config = ["projectKey": projectKey, "scope": scope, "clientId": clientId, "clientSecret": clientSecret]
             Commercetools.config = Config(config: config)
+        } else {
+            Log.error("No configuration with extended scope found in environment variables. This configuration is" +
+                      " needed to run the test successfully.")
         }
     }
     


### PR DESCRIPTION
@cneijenhuis @lauraluiz - as agreed, our tests which need higher scope are now using client credentials from the environment variables. Those are set in Travis and hidden, so they're not displayed in the output log.