### PR TITLE
Closes #62 Supoprt active cart

### DIFF
--- a/Commercetools.xcodeproj/project.pbxproj
+++ b/Commercetools.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		210BE6C3063D6C460F6D8601 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE4DCEEE2B368FC013FF0 /* Order.swift */; };
 		210BE7E502CA456C30566881 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE57833F74D2656716AF8 /* Error.swift */; };
 		210BE80CB72C73E5D330AA32 /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE3AEF096B27E48F86A4B /* Cart.swift */; };
+		210BE9B7A4D7D1BE572FE27D /* ActiveCart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BE4751F066B02CE24C3BF /* ActiveCart.swift */; };
 		210BE9F03FC6EB74CA205C35 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEAADF7135452064FD935 /* Log.swift */; };
 		210BE9FDDE49F1D7D4F53430 /* UpdateByKeyEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEC0502A7456AB50DC1B1 /* UpdateByKeyEndpointTests.swift */; };
 		210BEA16377561C1FC741F28 /* CreateEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210BEF918E99658EE26EA2EE /* CreateEndpointTests.swift */; };
@@ -43,6 +44,7 @@
 		21C6080B1CE006EE001A68A7 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 21C608091CE006EE001A68A7 /* Info.plist */; };
 		21C6534D1CBE6292008E84B2 /* Commercetools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21C653421CBE6291008E84B2 /* Commercetools.framework */; };
 		21C653521CBE6292008E84B2 /* AuthManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C653511CBE6292008E84B2 /* AuthManagerTests.swift */; };
+		21D462041D23FD0A00CB8C8E /* CartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D462031D23FD0A00CB8C8E /* CartTests.swift */; };
 		21F26D8F1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */; };
 		5282479BE674314D916A0355 /* Pods_Commercetools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A456D0DAC39F1D37C1FEDB0 /* Pods_Commercetools.framework */; };
 /* End PBXBuildFile section */
@@ -63,6 +65,7 @@
 		210BE2D37FC5D53E1528CEBB /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		210BE36824D8A23C8CFDB13F /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		210BE3AEF096B27E48F86A4B /* Cart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cart.swift; sourceTree = "<group>"; };
+		210BE4751F066B02CE24C3BF /* ActiveCart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveCart.swift; sourceTree = "<group>"; };
 		210BE4DCEEE2B368FC013FF0 /* Order.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
 		210BE57833F74D2656716AF8 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		210BE57902D25B9BD0342A69 /* Customer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
@@ -95,6 +98,7 @@
 		21C653421CBE6291008E84B2 /* Commercetools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commercetools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		21C6534C1CBE6292008E84B2 /* CommercetoolsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CommercetoolsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21C653511CBE6292008E84B2 /* AuthManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManagerTests.swift; sourceTree = "<group>"; };
+		21D462031D23FD0A00CB8C8E /* CartTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CartTests.swift; sourceTree = "<group>"; };
 		21F26D8E1CD0B8B100DFFEB8 /* XCTestCase+Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Configuration.swift"; sourceTree = "<group>"; };
 		29502A041BA37E6BD22C3C21 /* Pods-Commercetools.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Commercetools.release.xcconfig"; path = "Pods/Target Support Files/Pods-Commercetools/Pods-Commercetools.release.xcconfig"; sourceTree = "<group>"; };
 		9A456D0DAC39F1D37C1FEDB0 /* Pods_Commercetools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Commercetools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,6 +138,7 @@
 			children = (
 				2111C3F41CD7831D00B2C082 /* CustomerTests.swift */,
 				213398181CDB8BB2003248BD /* ProductProjectionTests.swift */,
+				21D462031D23FD0A00CB8C8E /* CartTests.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -147,6 +152,7 @@
 				210BEB9F8FEDA82BE1A8C60E /* ProductProjection.swift */,
 				210BE258C80D22ECAA4660A4 /* ProductType.swift */,
 				210BEEDD69E4AAC50AE994C4 /* Category.swift */,
+				210BE4751F066B02CE24C3BF /* ActiveCart.swift */,
 			);
 			path = Endpoints;
 			sourceTree = "<group>";
@@ -415,6 +421,7 @@
 				210BE30354065747CA48F92C /* ProductProjection.swift in Sources */,
 				210BE46ADE08AB809FFB22DD /* ProductType.swift in Sources */,
 				210BE66645DA622BEE3ED25A /* Category.swift in Sources */,
+				210BE9B7A4D7D1BE572FE27D /* ActiveCart.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -433,6 +440,7 @@
 				210BEDE9A321298095FE617F /* ByIdEndpointTests.swift in Sources */,
 				210BE27112B084029788BD8A /* QueryEndpointTests.swift in Sources */,
 				2111C3F51CD7831D00B2C082 /* CustomerTests.swift in Sources */,
+				21D462041D23FD0A00CB8C8E /* CartTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ The following list represents currently supported abstract endpoints. For each p
 #### Cart
 
 Cart endpoint supports all common operations:
+- Retrieve active cart (user must be logged in)
+```swift
+Cart.active(result: { result in
+    if let response = result.response where result.isSuccess {
+        // Cart successfully retrieved, response contains currently active cart in dictionary representation
+    }
+})
+```
 - Query for carts (user must be logged in)
 ```swift
 Cart.query(limit: 2, offset: 1, result: { result in

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -129,7 +129,6 @@ public class AuthManager {
                 self.logoutUser()
             }
             self.processLoginUser(username, password: password, completionHandler: { token, error in
-                print("\(token) access token")
                 completionHandler(error)
                 dispatch_semaphore_signal(semaphore)
             })

--- a/Source/AuthManager.swift
+++ b/Source/AuthManager.swift
@@ -129,6 +129,7 @@ public class AuthManager {
                 self.logoutUser()
             }
             self.processLoginUser(username, password: password, completionHandler: { token, error in
+                print("\(token) access token")
                 completionHandler(error)
                 dispatch_semaphore_signal(semaphore)
             })

--- a/Source/Endpoints/ActiveCart.swift
+++ b/Source/Endpoints/ActiveCart.swift
@@ -8,9 +8,9 @@ import Alamofire
 /**
     Provides access to active cart endpoint.
 */
-public class ActiveCart: Endpoint {
+class ActiveCart: Endpoint {
 
-    public static let path = "me/active-cart"
+    static let path = "me/active-cart"
 
     /**
         Retrieves the cart with state Active which has the most recent lastModifiedAt.

--- a/Source/Endpoints/ActiveCart.swift
+++ b/Source/Endpoints/ActiveCart.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+/**
+    Provides access to active cart endpoint.
+*/
+public class ActiveCart: Endpoint {
+
+    public static let path = "me/active-cart"
+
+    /**
+        Retrieves the cart with state Active which has the most recent lastModifiedAt.
+
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    static func get(expansion: [String]? = nil, result: (Result<[String: AnyObject], NSError>) -> Void) {
+        guard let config = Config.currentConfig, path = fullPath where config.validate() else {
+            Log.error("Cannot execute byId command - check if the configuration is valid.")
+            result(Result.Failure([Error.error(code: .GeneralCommercetoolsError)]))
+            return
+        }
+
+        AuthManager.sharedInstance.token { token, error in
+            guard let token = token else {
+                result(Result.Failure([error ?? Error.error(code: .GeneralCommercetoolsError)]))
+                return
+            }
+
+            let fullPath = pathWithExpansion(path, expansion: expansion)
+
+            Alamofire.request(.GET, fullPath, parameters: nil, encoding: .JSON, headers: self.headers(token))
+            .responseJSON(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), completionHandler: { response in
+                handleResponse(response, result: result)
+            })
+        }
+    }
+
+}

--- a/Source/Endpoints/Cart.swift
+++ b/Source/Endpoints/Cart.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import Alamofire
 
 /**
     Provides complete set of interactions for querying, retrieving, creating and updating shopping cart.
@@ -10,5 +11,15 @@ import Foundation
 public class Cart: QueryEndpoint, ByIdEndpoint, CreateEndpoint, UpdateEndpoint, DeleteEndpoint {
 
     public static let path = "me/carts"
+
+    /**
+        Retrieves the cart with state Active which has the most recent lastModifiedAt.
+
+        - parameter expansion:                An optional array of expansion property names.
+        - parameter result:                   The code to be executed after processing the response.
+    */
+    static func active(expansion: [String]? = nil, result: (Result<[String: AnyObject], NSError>) -> Void) {
+        return ActiveCart.get(expansion, result: result)
+    }
 
 }

--- a/Tests/Endpoints/CartTests.swift
+++ b/Tests/Endpoints/CartTests.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016 Commercetools. All rights reserved.
+//
+
+import XCTest
+@testable import Commercetools
+
+class CartTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        setupTestConfiguration()
+    }
+
+    override func tearDown() {
+        cleanPersistedTokens()
+        super.tearDown()
+    }
+    
+    func testRetrieveActiveCart() {
+        let activeCartExpectation = expectationWithDescription("active cart expectation")
+
+        let username = "swift.sdk.test.user2@commercetools.com"
+        let password = "password"
+
+        AuthManager.sharedInstance.loginUser(username, password: password, completionHandler: {_ in})
+
+        Cart.create(["currency": "EUR"], result: { result in
+            if let response = result.response, cartState = response["cartState"] as? String, id = response["id"] as? String
+                    where result.isSuccess && cartState == "Active" {
+                Cart.active(result: { result in
+                    if let response = result.response, activeCartId = response["id"] as? String where activeCartId == id {
+                        activeCartExpectation.fulfill()
+                    }
+                })
+            }
+        })
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+    
+}


### PR DESCRIPTION
The reason to introduce another class - `ActiveCart` - was to accommodate our endpoints structure. If our API path was `me/carts/active` instead of `me/active-cart` we could've done it without this additional class.

I also added static method `active` to the original `Cart` class, as a shortcut for easier access, which practically gives the user ability to access active cart with `Cart.active(...)`